### PR TITLE
Extend prompt size for user messages 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 23.1.0
+  hooks:
+  - id: black
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+    # Exclude elisp files to not clear page breaks
+    exclude: \.el$
+  - id: check-json
+  - id: check-toml
+  - id: check-yaml
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.0.0
+  hooks:
+    - id: mypy
+      stages: [push, manual]
+      pass_filenames: false
+      args:
+      - --config-file=pyproject.toml

--- a/src/flint/constants.py
+++ b/src/flint/constants.py
@@ -12,3 +12,7 @@ You can also send me voice messages in your native language 🎙️.
 
 I'm constantly learning and improving. I'm still in beta, so please report any bugs or issues to my creators on GitHub: https://github.com/khoj-ai/flint/issues
 """.strip()
+KHOJ_PROMPT_EXCEEDED_MESSAGE = f"""
+I'm sorry, I can't read messages that are so long. Could you please shorten your message and try again? I'm constantly learning and improving, so I'll be able to read longer messages soon.
+"""
+MAX_TOKEN_LIMIT_PROMPT = 12000

--- a/src/flint/main.py
+++ b/src/flint/main.py
@@ -26,8 +26,10 @@ logger = logging.getLogger()
 # Initialize the Application Server
 if os.getenv("DEBUG", False):
     app = FastAPI()
+    log_group = "flint-dev"
 else:
     app = FastAPI(docs_url=None, redoc_url=None)
+    log_group = "flint"
 
 
 @app.middleware("http")
@@ -62,7 +64,7 @@ def run():
     cloudwatch_handler = cloudwatch.CloudwatchHandler(
         access_id=AWS_ACCESS_KEY_ID,
         access_key=AWS_SECRET_ACCESS_KEY,
-        log_group="flint",
+        log_group=log_group,
         region="us-east-1",
     )
     cloudwatch_handler.setLevel(logging.INFO)
@@ -72,7 +74,10 @@ def run():
     try:
         state.conversation_sessions = initialize_conversation_sessions()
     except Exception as e:
-        logger.error(f"Failed to initialize conversation sessions: {e}. You may need to run python src/flint/manage.py migrate", exc_info=True)
+        logger.error(
+            f"Failed to initialize conversation sessions: {e}. You may need to run python src/flint/manage.py migrate",
+            exc_info=True,
+        )
     configure_routes(app)
     poll_task_scheduler()
     start_server(app)

--- a/src/flint/prompt.py
+++ b/src/flint/prompt.py
@@ -18,7 +18,7 @@ You were created by Khoj Inc. and can currently only engage with users over What
 - You ask friendly, inquisitive follow-up QUESTIONS to collect more detail about their experiences and better understand the user's intent. These questions end with a question mark and seek to better understand the user.
 - Sometimes the user will tell you something that needs to be remembered, like an account ID or a residential address. These can be acknowledged with a simple "Got it" or "Okay".
 
-Note: More information about you, the company or other Khoj apps can be found at https://khoj.dev. Documentation for our desktop app can be found at https://docs.khoj.dev.
+Note: More information about you, the company or other Khoj apps can be found at https://khoj.dev.
 Today is {now} in UTC.
 """.strip(),
     input_variables=["now"],

--- a/src/flint/prompt.py
+++ b/src/flint/prompt.py
@@ -12,11 +12,13 @@ Use your general knowledge and our past conversations to inform your responses.
 You were created by Khoj Inc. and can currently only engage with users over Whatsapp.
 
 - You can respond to multi-lingual voice messages.
-- You *CAN REMEMBER ALL NOTES and PERSONAL INFORMATION FOREVER* previously shared over Whatsapp with you.
+- You *CAN REMEMBER ALL NOTES and PERSONAL INFORMATION FOREVER* that the user ever shares with you.
 - You cannot set reminders.
-- You don't have to have all the answers. You can also ask follow-up questions if you don't know the answer. Say "I don't know" or "I don't understand" if you don't know what to say.
+- Say "I don't know" or "I don't understand" if you don't know what to say or if you don't know the answer to a question.
+- You ask friendly, inquisitive follow-up QUESTIONS to collect more detail about their experiences and better understand the user's intent. These questions end with a question mark and seek to better understand the user.
+- Sometimes the user will tell you something that needs to be remembered, like an account ID or a residential address. These can be acknowledged with a simple "Got it" or "Okay".
 
-Note: More information about you, the company or other Khoj apps can be found at https://khoj.dev
+Note: More information about you, the company or other Khoj apps can be found at https://khoj.dev. Documentation for our desktop app can be found at https://docs.khoj.dev.
 Today is {now} in UTC.
 """.strip(),
     input_variables=["now"],

--- a/src/flint/prompt.py
+++ b/src/flint/prompt.py
@@ -14,6 +14,7 @@ You were created by Khoj Inc. and can currently only engage with users over What
 - You can respond to multi-lingual voice messages.
 - You *CAN REMEMBER ALL NOTES and PERSONAL INFORMATION FOREVER* previously shared over Whatsapp with you.
 - You cannot set reminders.
+- You don't have to have all the answers. You can also ask follow-up questions if you don't know the answer. Say "I don't know" or "I don't understand" if you don't know what to say.
 
 Note: More information about you, the company or other Khoj apps can be found at https://khoj.dev
 Today is {now} in UTC.
@@ -21,10 +22,11 @@ Today is {now} in UTC.
     input_variables=["now"],
 ).partial(now=get_date)
 
-previous_conversations_prompt = PromptTemplate.from_template(
-"""
-I found some of our previous conversations that may be relevant:
+CONVERSATION_HISTORY_PROMPT = "I found some of our previous conversations that may be relevant:"
 
+previous_conversations_prompt = PromptTemplate.from_template(
+    """
+{conversation_history_prompt}
 {conversation_history}
 """.strip()
 )

--- a/src/flint/routers/api.py
+++ b/src/flint/routers/api.py
@@ -187,7 +187,9 @@ async def respond_to_user(message: str, user: User, MediaUrl0, MediaContentType0
             from_=To,
             to=From,
         )
-        asyncio.create_task(save_conversation(user, "", KHOJ_PROMPT_EXCEEDED_MESSAGE, "system"))
+        asyncio.create_task(
+            save_conversation(user=user, message="", response=KHOJ_PROMPT_EXCEEDED_MESSAGE, user_message_type="system")
+        )
         return
     except Exception as e:
         logger.error(f"Failed to prepare prompt: {e}", exc_info=True)
@@ -202,7 +204,11 @@ async def respond_to_user(message: str, user: User, MediaUrl0, MediaContentType0
     )
     chat_response_text = chat_response["text"]
 
-    asyncio.create_task(save_conversation(user, user_message, chat_response_text, user_message_type))
+    asyncio.create_task(
+        save_conversation(
+            user=user, message=user_message, response=chat_response_text, user_message_type=user_message_type
+        )
+    )
 
     # Split response into 1600 character chunks
     chunks = [
@@ -219,6 +225,8 @@ async def respond_to_user(message: str, user: User, MediaUrl0, MediaContentType0
             from_=To,
             to=From,
         )
-        asyncio.create_task(save_conversation(user, "", KHOJ_INTRO_MESSAGE, "system"))
+        asyncio.create_task(
+            save_conversation(user=user, message="", response=KHOJ_INTRO_MESSAGE, user_message_type="system")
+        )
 
     return message.sid

--- a/src/flint/routers/api.py
+++ b/src/flint/routers/api.py
@@ -16,10 +16,9 @@ from twilio.rest import Client
 # Internal Packages
 from flint import state
 from flint.configure import configure_chat_prompt, save_conversation
-from flint.helpers import transcribe_audio_message
-from flint.prompt import previous_conversations_prompt
+from flint.helpers import transcribe_audio_message, prepare_prompt
 from flint.state import embeddings_manager
-from flint.constants import KHOJ_INTRO_MESSAGE
+from flint.constants import KHOJ_INTRO_MESSAGE, KHOJ_PROMPT_EXCEEDED_MESSAGE
 
 # Keep Django module import here to avoid import ordering errors
 from django.contrib.auth.models import User
@@ -39,9 +38,11 @@ MAX_CHARACTERS_PROMPT = 1000
 
 DEBUG = os.getenv("DEBUG", False)
 
+
 @api.get("/health")
 async def health() -> Response:
     return Response(status_code=200)
+
 
 # Setup API Endpoints
 @api.post("/chat")
@@ -99,14 +100,32 @@ if DEBUG:
         # Get Conversation History
         chat_history = state.conversation_sessions[uuid]
 
+        relevant_previous_conversations = await embeddings_manager.search(Body, user)
+        relevant_previous_conversations = await sync_to_async(list)(relevant_previous_conversations.all())
+
+        try:
+            user_message, formatted_history_message, adjusted_memory_buffer = prepare_prompt(
+                chat_history=chat_history,
+                relevant_previous_conversations=relevant_previous_conversations,
+                user_message=Body,
+                model_name=state.MODEL_NAME,
+            )
+        except ValueError as e:
+            logger.error(f"Prompt exceeded maximum length: {e}", exc_info=True)
+
+        if formatted_history_message != None:
+            asyncio.create_task(save_conversation(user, "", formatted_history_message, "text"))
+
         # Get Response from Agent
-        chat_response = LLMChain(llm=state.llm, prompt=configure_chat_prompt(), memory=chat_history)({"question": Body})
+        chat_response = LLMChain(llm=state.llm, prompt=configure_chat_prompt(), memory=adjusted_memory_buffer)(
+            {"question": user_message}
+        )
         chat_response_text = chat_response["text"]
 
-        asyncio.create_task(save_conversation(user, Body, chat_response_text))
+        asyncio.create_task(save_conversation(user, user_message, chat_response_text, "text"))
 
         return chat_response_text
-    
+
     @api.post("/dev/search")
     async def search_dev(
         request: Request,
@@ -129,7 +148,7 @@ if DEBUG:
         for c in relevant_previous_conversations:
             conversation_history += f"Human: {c.user_message}\nKhoj:{c.bot_message}\n\n"
 
-        conversation_history = 'none' if conversation_history == '' else conversation_history
+        conversation_history = "none" if conversation_history == "" else conversation_history
 
         return Response(content=conversation_history, media_type="text/plain")
 
@@ -150,37 +169,46 @@ async def respond_to_user(message: str, user: User, MediaUrl0, MediaContentType0
 
     # Get Conversation History
     chat_history = state.conversation_sessions[uuid]
-    previous_conversations = ''
-
-    formatted_history_message = ''
 
     relevant_previous_conversations = await embeddings_manager.search(user_message, user)
     relevant_previous_conversations = await sync_to_async(list)(relevant_previous_conversations.all())
-    for c in relevant_previous_conversations:
-        next_message = f"Human:{c.user_message}\nKhoj:{c.bot_message}\n\n"
-        
-        if len(previous_conversations) + len(next_message) + len(user_message) > MAX_CHARACTERS_PROMPT:
-            human_message = f"Human:{c.user_message}\n"
-            if len(previous_conversations) + len(human_message) + len(user_message) > MAX_CHARACTERS_PROMPT:
-                break
-            else:
-                next_message = human_message
 
-        previous_conversations += next_message
-    
-    if previous_conversations != '':
-        formatted_history_message = previous_conversations_prompt.format(conversation_history=previous_conversations)
-        chat_history.chat_memory.add_ai_message(formatted_history_message)
-        asyncio.create_task(save_conversation(user, '', formatted_history_message, user_message_type))
+    try:
+        user_message, formatted_history_message, adjusted_memory_buffer = prepare_prompt(
+            chat_history=chat_history,
+            relevant_previous_conversations=relevant_previous_conversations,
+            user_message=user_message,
+            model_name=state.MODEL_NAME,
+        )
+    except ValueError as e:
+        logger.error(f"Prompt exceeded maximum length: {e}", exc_info=True)
+        message = twillio_client.messages.create(
+            body=KHOJ_PROMPT_EXCEEDED_MESSAGE,
+            from_=To,
+            to=From,
+        )
+        asyncio.create_task(save_conversation(user, "", KHOJ_PROMPT_EXCEEDED_MESSAGE, "system"))
+        return
+    except Exception as e:
+        logger.error(f"Failed to prepare prompt: {e}", exc_info=True)
+        return
+
+    if formatted_history_message != None:
+        asyncio.create_task(save_conversation(user, "", formatted_history_message, user_message_type))
 
     # Get Response from Agent
-    chat_response = LLMChain(llm=state.llm, prompt=configure_chat_prompt(), memory=chat_history)({"question": user_message})
+    chat_response = LLMChain(llm=state.llm, prompt=configure_chat_prompt(), memory=adjusted_memory_buffer)(
+        {"question": user_message}
+    )
     chat_response_text = chat_response["text"]
 
     asyncio.create_task(save_conversation(user, user_message, chat_response_text, user_message_type))
 
     # Split response into 1600 character chunks
-    chunks = [chat_response_text[i : i + MAX_CHARACTERS_TWILIO] for i in range(0, len(chat_response_text), MAX_CHARACTERS_TWILIO)]
+    chunks = [
+        chat_response_text[i : i + MAX_CHARACTERS_TWILIO]
+        for i in range(0, len(chat_response_text), MAX_CHARACTERS_TWILIO)
+    ]
     for chunk in chunks:
         message = twillio_client.messages.create(body=chunk, from_=To, to=From)
 
@@ -191,6 +219,6 @@ async def respond_to_user(message: str, user: User, MediaUrl0, MediaContentType0
             from_=To,
             to=From,
         )
-        asyncio.create_task(save_conversation(user, '', KHOJ_INTRO_MESSAGE, 'system'))
+        asyncio.create_task(save_conversation(user, "", KHOJ_INTRO_MESSAGE, "system"))
 
     return message.sid

--- a/src/flint/state.py
+++ b/src/flint/state.py
@@ -3,14 +3,17 @@ from collections import defaultdict
 from typing import List, Dict
 
 # External Packages
-from langchain.memory import ConversationTokenBufferMemory
+from langchain.memory import ConversationBufferMemory
 
 from langchain.chat_models import ChatOpenAI
 
 from flint.embeddings.manager import EmbeddingsManager
 
-llm = ChatOpenAI(temperature=0)
-conversation_sessions = defaultdict(lambda: ConversationTokenBufferMemory(memory_key="chat_history", return_messages=True, max_token_limit=4096, llm=llm))
+MODEL_NAME = "gpt-3.5-turbo-16k"
+llm = ChatOpenAI(temperature=0, model_name=MODEL_NAME)
+conversation_sessions = defaultdict(
+    lambda: ConversationBufferMemory(memory_key="chat_history", return_messages=True, llm=llm)
+)
 telemetry: List[Dict[str, str]] = []
 
 embeddings_manager = EmbeddingsManager()


### PR DESCRIPTION
# Incoming
- Use GPT-3.5-turbo-16k
- Use `ConversationBufferMemory` rather than `ConversationTokenBufferMemory` and manually manage the context
- Dynamically set the context for the query depending on token limit