### PR TITLE
Productionize FastAPI application with gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,5 @@ RUN sed -i 's/dynamic = \["version"\]/version = "0.0.0"/' pyproject.toml && \
 # Make port 8488 available to the world outside this container
 EXPOSE 8488
 
-# Run src.flint.main.py when the container launches
-ENTRYPOINT ["python3", "src/flint/main.py"]
+# Run the gunicorn server with the FastAPI app
+ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:8488", "main:app", "-w", "4", "-k", "uvicorn.workers.UvicornH11Worker"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN sed -i 's/dynamic = \["version"\]/version = "0.0.0"/' pyproject.toml && \
 EXPOSE 8488
 
 # Run the gunicorn server with the FastAPI app
-ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:8488", "main:app", "-w", "4", "-k", "uvicorn.workers.UvicornH11Worker"]
+ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:8488", "src.flint.main:app", "--workers", "3", "-k", "uvicorn.workers.UvicornWorker", "--timeout", "600", "--keep-alive", "120", "--threads", "3"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN sed -i 's/dynamic = \["version"\]/version = "0.0.0"/' pyproject.toml && \
 EXPOSE 8488
 
 # Run the gunicorn server with the FastAPI app
-ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:8488", "src.flint.main:app", "--workers", "3", "-k", "uvicorn.workers.UvicornWorker", "--timeout", "600", "--keep-alive", "120", "--threads", "3"]
+ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:8488", "src.flint.main:app", "--workers", "3", "-k", "uvicorn.workers.UvicornWorker", "--timeout", "600", "--keep-alive", "120"]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -32,5 +32,5 @@ RUN sed -i 's/dynamic = \["version"\]/version = "0.0.0"/' pyproject.toml && \
 # Make port 8488 available to the world outside this container
 EXPOSE 8488
 
-# Run src.flint.main.py when the container launches
-ENTRYPOINT ["python3", "src/flint/main.py"]
+# Run the gunicorn server with the FastAPI app
+ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:8488", "src.flint.main:app", "-w", "4", "-k", "uvicorn.workers.UvicornH11Worker"]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -33,4 +33,4 @@ RUN sed -i 's/dynamic = \["version"\]/version = "0.0.0"/' pyproject.toml && \
 EXPOSE 8488
 
 # Run the gunicorn server with the FastAPI app
-ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:8488", "src.flint.main:app", "-w", "4", "-k", "uvicorn.workers.UvicornH11Worker"]
+ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:8488", "src.flint.main:app", "--workers", "2", "-k", "uvicorn.workers.UvicornWorker", "--timeout", "600", "--keep-alive", "120", "--threads", "2", "--worker-tmp-dir", "/dev/shm", "--log-level", "debug"]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -33,4 +33,4 @@ RUN sed -i 's/dynamic = \["version"\]/version = "0.0.0"/' pyproject.toml && \
 EXPOSE 8488
 
 # Run the gunicorn server with the FastAPI app
-ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:8488", "src.flint.main:app", "--workers", "2", "-k", "uvicorn.workers.UvicornWorker", "--timeout", "600", "--keep-alive", "120", "--threads", "2", "--worker-tmp-dir", "/dev/shm", "--log-level", "debug"]
+ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:8488", "src.flint.main:app", "--workers", "2", "-k", "uvicorn.workers.UvicornWorker", "--timeout", "600", "--keep-alive", "120", "--log-level", "debug"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "tiktoken >= 0.3.0",
     "sentence-transformers == 2.2.2",
     "cloudwatch == 1.0.5",
+    "gunicorn == 21.2.0",
  ]
 dynamic = ["version"]
 

--- a/src/flint/embeddings/manager.py
+++ b/src/flint/embeddings/manager.py
@@ -64,7 +64,8 @@ class EmbeddingsManager:
             ConversationVector.objects.filter(conversation__in=conversations_to_search)
             .alias(distance=CosineDistance("vector", embedded_query))
             .filter(distance__lte=0.20)
-            .order_by("distance")[:top_n]
+            .order_by("distance")
+            .only("conversation")[:top_n]
         )
 
         if not await sync_to_async(sorted_vectors.exists)():

--- a/src/flint/embeddings/manager.py
+++ b/src/flint/embeddings/manager.py
@@ -64,8 +64,7 @@ class EmbeddingsManager:
             ConversationVector.objects.filter(conversation__in=conversations_to_search)
             .alias(distance=CosineDistance("vector", embedded_query))
             .filter(distance__lte=0.20)
-            .order_by("distance")
-            .only("conversation")[:top_n]
+            .order_by("distance")[:top_n]
         )
 
         if not await sync_to_async(sorted_vectors.exists)():

--- a/src/flint/main.py
+++ b/src/flint/main.py
@@ -57,7 +57,7 @@ def poll_task_scheduler():
     schedule.run_pending()
 
 
-def run():
+def run(should_start_server=True):
     if not os.getenv("DEBUG", False):
         AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
         AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
@@ -81,8 +81,12 @@ def run():
         )
     configure_routes(app)
     poll_task_scheduler()
-    start_server(app)
+    if should_start_server:
+        start_server(app)
 
 
 if __name__ == "__main__":
     run()
+
+else:
+    run(should_start_server=False)


### PR DESCRIPTION
Use gunicorn to productionize the FastAPI service. See also [FastAPI - Gunicorn](https://fastapi.tiangolo.com/deployment/server-workers/) documentation for reference. I had to increase the `timeout` parameter to run in Docker.